### PR TITLE
force torch to CPU-only version

### DIFF
--- a/python/bin/get_package.py
+++ b/python/bin/get_package.py
@@ -183,7 +183,7 @@ def main() :
    else :
       pypi_name = {
          'autograd' : 'autograd' ,
-         'torch'    : 'torch'    ,
+         'torch'    : 'torch --index-url https://download.pytorch.org/whl/cpu'    ,
          'jax'      : 'jax[cpu]' ,
       }
       name  = pypi_name[package]


### PR DESCRIPTION
fixes #6 

cf https://pytorch.org/get-started/locally/